### PR TITLE
Updates react-router peer dep to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {},
   "peerDependencies": {
     "react": "0.14.x",
-    "react-router": "1.0.0-rc3||1.0.0-rc4"
+    "react-router": "^1.0.0"
   },
   "devDependencies": {
     "babel": "^5.8.26",


### PR DESCRIPTION
I didn't find any bugs when QAing the [company website](https://grovelabs.io) with `react-router` 1.0.0 and the most recent `react-g-analytics`. It'd be awesome if you could publish a new version to npm as well. Thanks!
